### PR TITLE
Add refresh functionality to recommendations

### DIFF
--- a/public/locales/en/ai.json
+++ b/public/locales/en/ai.json
@@ -92,6 +92,8 @@
     "no_interested": "No companies marked as interested",
     "no_not_interested": "No companies marked as not interested",
     "regenerate": "Regenerate Recommendations",
+    "refresh": "Refresh Recommendations",
+    "refreshing": "Refreshing...",
     "loading": {
       "title": "Finding Your Matches...",
       "description": "We're analyzing your values and preferences to find the best company matches for you."

--- a/public/locales/ja/ai.json
+++ b/public/locales/ja/ai.json
@@ -92,6 +92,8 @@
     "no_interested": "興味ありとマークした企業はありません",
     "no_not_interested": "興味なしとマークした企業はありません",
     "regenerate": "おすすめを再生成",
+    "refresh": "おすすめを更新",
+    "refreshing": "更新中...",
     "loading": {
       "title": "マッチを検索中...",
       "description": "あなたの価値観と好みを分析して、最適な企業マッチを見つけています。"

--- a/src/components/recommendations/RecommendationsContent.tsx
+++ b/src/components/recommendations/RecommendationsContent.tsx
@@ -35,9 +35,10 @@ export default function RecommendationsContent({
   >([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
   useEffect(() => {
-    const fetchRecommendations = async () => {
+    const fetchRecommendations = async (refresh = false) => {
       if (!userId) {
         setError(t("recommendations.errors.missing_user_id"));
         setLoading(false);
@@ -46,7 +47,7 @@ export default function RecommendationsContent({
 
       try {
         const response = await fetch(
-          `/api/recommendations?userId=${userId}&locale=${lng}`
+          `/api/recommendations?userId=${userId}&locale=${lng}${refresh ? '&refresh=true' : ''}`
         );
 
         if (!response.ok) {
@@ -60,6 +61,7 @@ export default function RecommendationsContent({
         setError(t("recommendations.errors.general"));
       } finally {
         setLoading(false);
+        setRefreshing(false);
       }
     };
 
@@ -67,6 +69,37 @@ export default function RecommendationsContent({
       fetchRecommendations();
     }
   }, [userId, t, loaded, lng]);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    const fetchRecommendations = async () => {
+      if (!userId) {
+        setError(t("recommendations.errors.missing_user_id"));
+        setRefreshing(false);
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/api/recommendations?userId=${userId}&locale=${lng}&refresh=true`
+        );
+
+        if (!response.ok) {
+          throw new Error(t("recommendations.errors.fetch_failed"));
+        }
+
+        const data = await response.json();
+        setRecommendations(data.recommendations);
+      } catch (err) {
+        console.error("Error fetching recommendations:", err);
+        setError(t("recommendations.errors.general"));
+      } finally {
+        setRefreshing(false);
+      }
+    };
+
+    fetchRecommendations();
+  };
 
   const handleFeedback = async (
     recommendationId: string,
@@ -174,6 +207,32 @@ export default function RecommendationsContent({
         <p className="text-lg text-center mb-8">
           {t("recommendations.description")}
         </p>
+
+        <div className="flex justify-end mb-4">
+          <Button 
+            onClick={handleRefresh} 
+            disabled={refreshing}
+            variant="outline"
+            className="flex items-center gap-2"
+          >
+            {refreshing ? (
+              <>
+                <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                </svg>
+                {t("recommendations.refreshing")}
+              </>
+            ) : (
+              <>
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                {t("recommendations.refresh")}
+              </>
+            )}
+          </Button>
+        </div>
 
         <Tabs defaultValue="all" className="w-full">
           <TabsList className="flex flex-wrap gap-2 h-full">


### PR DESCRIPTION
This pull request introduces a "Refresh Recommendations" feature to the recommendations section of the application. The changes include updates to the UI text for both English and Japanese locales, as well as modifications to the `RecommendationsContent` component to support refreshing recommendations.

### UI Text Updates:
* Added "Refresh Recommendations" and "Refreshing..." text to `public/locales/en/ai.json`.
* Added "おすすめを更新" and "更新中..." text to `public/locales/ja/ai.json`.

### Component Updates:
* Introduced a `refreshing` state in `RecommendationsContent` to manage the refresh process.
* Modified the `fetchRecommendations` function to accept a `refresh` parameter and updated the API call accordingly.
* Ensured that the `refreshing` state is reset after the API call completes.
* Added a `handleRefresh` function to trigger the refresh process and update the recommendations.
* Added a refresh button to the UI, which shows a loading spinner and disables itself while refreshing.