### PR TITLE
Update ValuesQuestionnaire to switch to text-based questions mode by …

### DIFF
--- a/src/components/forms/ValuesQuestionnaire.tsx
+++ b/src/components/forms/ValuesQuestionnaire.tsx
@@ -20,7 +20,7 @@ import {ImageQuestionGrid} from "./ImageValueSelector";
 import {getImageQuestions} from "@/lib/values/client";
 
 // A/B Testing Toggle - Set to false to use text-based questions, true to use only image-based questions
-const USE_ONLY_IMAGE_QUESTIONS = true;
+const USE_ONLY_IMAGE_QUESTIONS = false;
 
 // Number of random image questions to select
 const NUM_RANDOM_IMAGE_QUESTIONS = 5;


### PR DESCRIPTION
This pull request includes a small change to the `ValuesQuestionnaire.tsx` file. The change modifies the A/B testing toggle to use text-based questions instead of image-based questions.

* [`src/components/forms/ValuesQuestionnaire.tsx`](diffhunk://#diff-640fd139c374f191cc41dfbec941f660f828c708eaaf838ab261a6e51c6e3721L23-R23): Changed `USE_ONLY_IMAGE_QUESTIONS` from `true` to `false` to use text-based questions.