### PR TITLE
Revert fetching previous company recommendations

### DIFF
--- a/src/app/api/recommendations/route.ts
+++ b/src/app/api/recommendations/route.ts
@@ -60,30 +60,29 @@ export async function GET(request: Request) {
     }
 
     // Fetch previously recommended company names to avoid repetition and promote diversity
-    const {data: previouslyRecommendedCompanies, error: prevRecsError} = await supabase
-      .from("recommendations")
-      .select("company_id");
+    // const {data: previouslyRecommendedCompanies, error: prevRecsError} = await supabase
+    //   .from("recommendations")
+    //   .select("company_id");
 
-    if (prevRecsError) {
-      console.error("Error fetching previously recommended companies:", prevRecsError);
-      // Continue with the process, we'll just have less information about previous recommendations
-    }
+    // if (prevRecsError) {
+    //   console.error("Error fetching previously recommended companies:", prevRecsError);
+    //   // Continue with the process, we'll just have less information about previous recommendations
+    // }
 
-    // Get the actual company names from the IDs
-    const previousCompanyIds = previouslyRecommendedCompanies?.map(rec => rec.company_id) || [];
-    const {data: previousCompanies} = await supabase
-      .from("companies")
-      .select("name")
-      .in("id", previousCompanyIds.length > 0 ? previousCompanyIds : ['no-companies']);
+    // // Get the actual company names from the IDs
+    // const previousCompanyIds = previouslyRecommendedCompanies?.map(rec => rec.company_id) || [];
+    // const {data: previousCompanies} = await supabase
+    //   .from("companies")
+    //   .select("name")
+    //   .in("id", previousCompanyIds.length > 0 ? previousCompanyIds : ['no-companies']);
     
-    // Extract just the company names
-    const previousCompanyNames = previousCompanies?.map(company => company.name) || [];
+    // // Extract just the company names
+    // const previousCompanyNames = previousCompanies?.map(company => company.name) || [];
 
     // Generate new recommendations with real company data, passing the locale and previously recommended companies
     const recommendations = await generateRecommendations(
       userData,
       locale as "en" | "ja",
-      previousCompanyNames
     );
 
     // Save recommendations to Supabase


### PR DESCRIPTION
This pull request focuses on simplifying the recommendation generation process by removing the handling of previously recommended companies. The key changes involve commenting out the code that fetches and processes previously recommended companies, and updating the recommendation generation logic to exclude this information.

### Simplification of recommendation generation:

* [`src/app/api/recommendations/route.ts`](diffhunk://#diff-8ec625f6313727b6eb47ec27b6a7a4f8fd9ae174ca7c3e3aefbf1dcf16078ff2L63-L86): Commented out code that fetches and processes previously recommended companies to avoid repetition and promote diversity.

* [`src/lib/openai/client.ts`](diffhunk://#diff-7773c9c79b6e755eed5a9fc7fae569e75d2d8ffed32e87b4964ca5fd5a615969L72-R72): Removed the `previouslyRecommendedCompanies` parameter from the `generateRecommendations` function and updated the prompt templates to no longer reference previously recommended companies. [[1]](diffhunk://#diff-7773c9c79b6e755eed5a9fc7fae569e75d2d8ffed32e87b4964ca5fd5a615969L72-R72) [[2]](diffhunk://#diff-7773c9c79b6e755eed5a9fc7fae569e75d2d8ffed32e87b4964ca5fd5a615969L87-R90) [[3]](diffhunk://#diff-7773c9c79b6e755eed5a9fc7fae569e75d2d8ffed32e87b4964ca5fd5a615969L237-R231)