### PR TITLE
Fix/Preserve ad params

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useScrollDirection } from "@/hooks";
-import Link from "next/link";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import Image from "next/image";
+import { QueryLink } from "@/components/ui/link";
 
 export default function Header() {
   const { scrollDirection } = useScrollDirection(3);
@@ -16,7 +16,7 @@ export default function Header() {
     >
       <div className="mx-auto max-w-7xl">
         <div className="flex items-center justify-between p-4">
-          <Link 
+          <QueryLink 
             href="/" 
             className="text-xl font-bold transition-colors duration-200 hover:text-primary"
           >
@@ -27,7 +27,7 @@ export default function Header() {
               height={30} 
               priority
             />
-          </Link>
+          </QueryLink>
           <LanguageSwitcher />
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@
 import { useScrollDirection } from "@/hooks";
 import LanguageSwitcher from "@/components/LanguageSwitcher";
 import Image from "next/image";
-import { QueryLink } from "@/components/ui/link";
+import { Link } from "@/components/ui/link";
 
 export default function Header() {
   const { scrollDirection } = useScrollDirection(3);
@@ -16,7 +16,7 @@ export default function Header() {
     >
       <div className="mx-auto max-w-7xl">
         <div className="flex items-center justify-between p-4">
-          <QueryLink 
+          <Link 
             href="/" 
             className="text-xl font-bold transition-colors duration-200 hover:text-primary"
           >
@@ -27,7 +27,7 @@ export default function Header() {
               height={30} 
               priority
             />
-          </QueryLink>
+          </Link>
           <LanguageSwitcher />
         </div>
       </div>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,18 +1,24 @@
 'use client';
 
-import { useRouter, usePathname } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { languages } from '../i18n-config';
 import { Button } from './ui/button';
+import { createUrlWithParams } from '@/lib/utils';
 
 export default function LanguageSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   
   const switchLanguage = (locale: string) => {
     // Get the current path without the locale prefix
     const currentPath = pathname.split('/').slice(2).join('/');
-    // Navigate to the new locale path
-    router.push(`/${locale}/${currentPath}`);
+    
+    // Use the utility function to create a URL with preserved query parameters
+    const url = createUrlWithParams(`/${locale}/${currentPath}`, searchParams);
+    
+    // Navigate to the new locale path with preserved query parameters
+    router.push(url);
   };
 
   // Determine current language from pathname

--- a/src/components/forms/ValuesQuestionnaire.tsx
+++ b/src/components/forms/ValuesQuestionnaire.tsx
@@ -21,6 +21,7 @@ import {
   trackSurveyCompleted,
   trackSurveyStepAbandoned,
 } from "@/lib/analytics";
+import {createUrlWithParams} from "@/lib/utils";
 
 // A/B Testing Toggle - This will be overridden by the questionnaireType prop if provided
 const DEFAULT_QUESTIONNAIRE_TYPE = "text"; // "text" or "image"
@@ -958,8 +959,9 @@ export default function ValuesQuestionnaire({
   };
 
   const handleSubmit = async () => {
-    setIsSubmitting(true);
     try {
+      setIsSubmitting(true);
+      
       // Track survey completion
       const surveyDurationSeconds = Math.floor(
         (Date.now() - surveyStartTime) / 1000
@@ -1045,11 +1047,22 @@ export default function ValuesQuestionnaire({
       }
 
       const data = await response.json();
-
-      // Redirect to recommendations page with locale and userId
-      router.push(
-        `/${lng}/recommendations?userId=${data.userId}&locale=${lng}`
+      
+      // Use the utility function to create URL with preserved params from window.location.search
+      const searchParamsObj = new URLSearchParams(window.location.search);
+      const url = createUrlWithParams(
+        `/${lng}/recommendations`, 
+        searchParamsObj,
+        {
+          exclude: ['userId', 'type'],
+          include: {
+            userId: data.userId,
+          }
+        }
       );
+      
+      // Navigate to recommendations page
+      router.push(url);
     } catch (error) {
       console.error("Error submitting values:", error);
       // Handle error (show toast, etc.)

--- a/src/components/recommendations/RecommendationsContent.tsx
+++ b/src/components/recommendations/RecommendationsContent.tsx
@@ -23,6 +23,7 @@ import {
   trackRecommendationsPageVisit,
   trackCompanyInterestedClick,
 } from "@/lib/analytics";
+import { createUrlWithParams } from "@/lib/utils";
 
 interface RecommendationsContentProps {
   lng: string;
@@ -458,7 +459,12 @@ export default function RecommendationsContent({
             </CardHeader>
             <CardFooter className="flex justify-center">
               <Button
-                onClick={() => (window.location.href = `/${lng}/questionnaire`)}
+                onClick={() => {
+                  // Create URL with preserved query parameters 
+                  const currentParams = new URLSearchParams(window.location.search);
+                  const url = createUrlWithParams(`/${lng}/questionnaire`, currentParams);
+                  window.location.href = url;
+                }}
                 className="bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600"
               >
                 {t("recommendations.errors.try_again")}

--- a/src/components/ui/QuestionnaireOptions/QuestionnaireOptions.tsx
+++ b/src/components/ui/QuestionnaireOptions/QuestionnaireOptions.tsx
@@ -2,7 +2,7 @@
 
 import StarBorder from "@/components/ui/Animations/StarBorder/StarBorder";
 import {trackSurveyStartClick, trackSurveyTypeSelection} from "@/lib/analytics";
-import { QueryLink } from "@/components/ui/link";
+import { Link } from "@/components/ui/link";
 
 interface QuestionnaireOptionsProps {
   lng: string;
@@ -27,7 +27,7 @@ export default function QuestionnaireOptions({
     <div
       className={`space-y-4 sm:space-y-6  ${className}`}
     >
-        <QueryLink
+        <Link
           href={`/${lng}/questionnaire?type=text`}
           onClick={() => handleSurveyStart("text")}
         >
@@ -54,7 +54,7 @@ export default function QuestionnaireOptions({
               {lng === "ja" ? "始める" : "Start"}
             </span>
           </StarBorder>
-        </QueryLink>
+        </Link>
     </div>
   );
 

--- a/src/components/ui/QuestionnaireOptions/QuestionnaireOptions.tsx
+++ b/src/components/ui/QuestionnaireOptions/QuestionnaireOptions.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
 import StarBorder from "@/components/ui/Animations/StarBorder/StarBorder";
 import {trackSurveyStartClick, trackSurveyTypeSelection} from "@/lib/analytics";
+import { QueryLink } from "@/components/ui/link";
 
 interface QuestionnaireOptionsProps {
   lng: string;
@@ -27,7 +27,7 @@ export default function QuestionnaireOptions({
     <div
       className={`space-y-4 sm:space-y-6  ${className}`}
     >
-        <Link
+        <QueryLink
           href={`/${lng}/questionnaire?type=text`}
           onClick={() => handleSurveyStart("text")}
         >
@@ -54,7 +54,7 @@ export default function QuestionnaireOptions({
               {lng === "ja" ? "始める" : "Start"}
             </span>
           </StarBorder>
-        </Link>
+        </QueryLink>
     </div>
   );
 

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import React from 'react';
-import Link from 'next/link';
+import NextLink from 'next/link';
 import { useSearchParams } from 'next/navigation';
 
-interface QueryLinkProps extends React.ComponentPropsWithoutRef<typeof Link> {
+interface LinkProps extends React.ComponentPropsWithoutRef<typeof NextLink> {
   preserveQuery?: boolean;
 }
 
-export const QueryLink: React.FC<QueryLinkProps> = ({
+export const Link: React.FC<LinkProps> = ({
   href,
   preserveQuery = true,
   children,
@@ -18,7 +18,7 @@ export const QueryLink: React.FC<QueryLinkProps> = ({
   
   // If preserveQuery is false or there are no search params, just use the original href
   if (!preserveQuery || !searchParams.size) {
-    return <Link href={href} {...props}>{children}</Link>;
+    return <NextLink href={href} {...props}>{children}</NextLink>;
   }
 
   // Convert href to string if it's an object
@@ -37,7 +37,7 @@ export const QueryLink: React.FC<QueryLinkProps> = ({
     ? `${hrefString}&${queryString}` 
     : `${hrefString}${queryString ? `?${queryString}` : ''}`;
 
-  return <Link href={newHref} {...props}>{children}</Link>;
+  return <NextLink href={newHref} {...props}>{children}</NextLink>;
 };
 
-export default QueryLink; 
+export default Link; 

--- a/src/components/ui/link.tsx
+++ b/src/components/ui/link.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+interface QueryLinkProps extends React.ComponentPropsWithoutRef<typeof Link> {
+  preserveQuery?: boolean;
+}
+
+export const QueryLink: React.FC<QueryLinkProps> = ({
+  href,
+  preserveQuery = true,
+  children,
+  ...props
+}) => {
+  const searchParams = useSearchParams();
+  
+  // If preserveQuery is false or there are no search params, just use the original href
+  if (!preserveQuery || !searchParams.size) {
+    return <Link href={href} {...props}>{children}</Link>;
+  }
+
+  // Convert href to string if it's an object
+  const hrefString = typeof href === 'object' 
+    ? href.pathname || '/' 
+    : href.toString();
+
+  // Check if href already has query parameters
+  const hasQueryParams = hrefString.includes('?');
+
+  // Create the query string from current search params
+  const queryString = searchParams.toString();
+  
+  // Append the query string to the href
+  const newHref = hasQueryParams 
+    ? `${hrefString}&${queryString}` 
+    : `${hrefString}${queryString ? `?${queryString}` : ''}`;
+
+  return <Link href={newHref} {...props}>{children}</Link>;
+};
+
+export default QueryLink; 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,56 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
+/**
+ * Combines class names using clsx and tailwind-merge
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+/**
+ * Creates a URL with preserved query parameters
+ * @param baseUrl - The base URL to navigate to (e.g., "/en/admin")
+ * @param searchParams - The current search parameters from useSearchParams()
+ * @param options - Additional options
+ * @param options.exclude - Array of parameter names to exclude
+ * @param options.include - Object of parameter names and values to include/override
+ * @returns Complete URL with query parameters
+ */
+export function createUrlWithParams(
+  baseUrl: string,
+  searchParams: URLSearchParams,
+  options: {
+    exclude?: string[];
+    include?: Record<string, string>;
+  } = {}
+): string {
+  // Create a copy of the current search params
+  const params = new URLSearchParams(searchParams.toString());
+  
+  // Remove excluded parameters
+  if (options.exclude) {
+    options.exclude.forEach(param => params.delete(param));
+  }
+  
+  // Add or override included parameters
+  if (options.include) {
+    Object.entries(options.include).forEach(([key, value]) => {
+      params.set(key, value);
+    });
+  }
+  
+  // Construct the final URL
+  const queryString = params.toString();
+  const hasQueryInBaseUrl = baseUrl.includes('?');
+  
+  if (!queryString) {
+    return baseUrl;
+  }
+  
+  if (hasQueryInBaseUrl) {
+    return `${baseUrl}&${queryString}`;
+  }
+  
+  return `${baseUrl}?${queryString}`;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,7 +32,15 @@ export function middleware(request: NextRequest) {
     // If not authenticated, redirect to the login page
     if (!adminSession || adminSession.value !== 'authenticated') {
       const url = new URL(`/${getLocale(request)}/admin/login`, request.url);
+      
+      // Preserve the original query parameters
+      request.nextUrl.searchParams.forEach((value, key) => {
+        url.searchParams.set(key, value);
+      });
+      
+      // Add the redirect parameter
       url.searchParams.set('redirect', pathname);
+      
       return NextResponse.redirect(url);
     }
     
@@ -60,15 +68,20 @@ export function middleware(request: NextRequest) {
   // Redirect if there is no locale
   if (pathnameIsMissingLocale) {
     const locale = getLocale(request);
-
-    // e.g. incoming request is /products
-    // The new URL is now /en/products
-    return NextResponse.redirect(
-      new URL(
-        `/${locale}${pathname.startsWith('/') ? '' : '/'}${pathname}`,
-        request.url
-      )
+    
+    // Create new URL with the locale prefix
+    const newUrl = new URL(
+      `/${locale}${pathname.startsWith('/') ? '' : '/'}${pathname}`,
+      request.url
     );
+    
+    // Preserve all query parameters from the original request
+    request.nextUrl.searchParams.forEach((value, key) => {
+      newUrl.searchParams.set(key, value);
+    });
+    
+    // Redirect to the new URL
+    return NextResponse.redirect(newUrl);
   }
 
   // Get the response


### PR DESCRIPTION
This pull request introduces several changes to improve URL handling and preserve query parameters across different components. The most important changes include creating a utility function to manage URLs with query parameters, updating components to use this utility function, and modifying the `Link` component to preserve query parameters.

Improvements to URL handling:

* [`src/lib/utils.ts`](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224R4-R56): Added the `createUrlWithParams` utility function to create URLs with preserved query parameters.

Component updates to use the new utility function:

* [`src/components/LanguageSwitcher.tsx`](diffhunk://#diff-d5e5bf64ec4a5e2638a8bab847c13d74fb80a459105744de502ecbcb15a04549L3-R21): Updated the `switchLanguage` function to use `createUrlWithParams` for navigating with preserved query parameters.
* [`src/components/forms/ValuesQuestionnaire.tsx`](diffhunk://#diff-640fd139c374f191cc41dfbec941f660f828c708eaaf838ab261a6e51c6e3721L1049-R1065): Modified the form submission to use `createUrlWithParams` for redirecting with preserved query parameters.
* [`src/components/recommendations/RecommendationsContent.tsx`](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L461-R467): Updated the button click handler to use `createUrlWithParams` for URL navigation with preserved query parameters.

Enhancements to the `Link` component:

* [`src/components/ui/link.tsx`](diffhunk://#diff-7bb7e8340afb2339b05c8930f86dab2e4927878f3daefb30b925f8d7d7087232R1-R43): Created a custom `Link` component that preserves query parameters by default.

Middleware adjustments to preserve query parameters:

* [`src/middleware.ts`](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R35-R43): Modified redirects to preserve original query parameters when redirecting to authenticated or localized paths. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0R35-R43) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L64-R84)