### PR TITLE
Remove home page and redirect to questionnaire on initial visit

### DIFF
--- a/src/app/[lng]/page.tsx
+++ b/src/app/[lng]/page.tsx
@@ -1,65 +1,66 @@
-import {getTranslation} from "@/i18n-server";
-import BackgroundEffects from "@/components/ui/BackgroundEffects/BackgroundEffects";
-import FloatingDecorations from "@/components/ui/FloatingDecorations/FloatingDecorations";
-import HeroSection from "@/components/sections/HeroSection/HeroSection";
-import FeaturesSection from "@/components/sections/FeaturesSection/FeaturesSection";
-import Footer from "@/components/ui/Footer/Footer";
-import HomePageTracker from "@/components/analytics/HomePageTracker";
-
+// import {getTranslation} from "@/i18n-server";
+// import BackgroundEffects from "@/components/ui/BackgroundEffects/BackgroundEffects";
+// import FloatingDecorations from "@/components/ui/FloatingDecorations/FloatingDecorations";
+// import HeroSection from "@/components/sections/HeroSection/HeroSection";
+// import FeaturesSection from "@/components/sections/FeaturesSection/FeaturesSection";
+// import Footer from "@/components/ui/Footer/Footer";
+// import HomePageTracker from "@/components/analytics/HomePageTracker";
+import { redirect } from "next/navigation";
 export default function Home({params}: {params: Promise<{lng: string}>}) {
   // Use an async IIFE to handle the Promise
   const HomeContent = async () => {
     const resolvedParams = await params;
     const lng = resolvedParams.lng;
-    const {t} = await getTranslation(lng, "common");
+    // const {t} = await getTranslation(lng, "common");
+    redirect(`/${lng}/questionnaire`);
 
-    const features = [
-      {
-        title: t("features.quick.title"),
-        description: t("features.quick.description"),
-        color: "blue" as const,
-      },
-      {
-        title: t("features.values.title"),
-        description: t("features.values.description"),
-        color: "purple" as const,
-      },
-      {
-        title: t("features.insights.title"),
-        description: t("features.insights.description"),
-        color: "pink" as const,
-      },
-    ];
+    // const features = [
+    //   {
+    //     title: t("features.quick.title"),
+    //     description: t("features.quick.description"),
+    //     color: "blue" as const,
+    //   },
+    //   {
+    //     title: t("features.values.title"),
+    //     description: t("features.values.description"),
+    //     color: "purple" as const,
+    //   },
+    //   {
+    //     title: t("features.insights.title"),
+    //     description: t("features.insights.description"),
+    //     color: "pink" as const,
+    //   },
+    // ];
 
-    const heroProps = {
-      title: t("homepage.title"),
-      description: t("homepage.description"),
-      lng: lng,
-    };
+    // const heroProps = {
+    //   title: t("homepage.title"),
+    //   description: t("homepage.description"),
+    //   lng: lng,
+    // };
 
-    const featuresProps = {
-      title: t("features.quick.title") || "Why Choose Us",
-      features: features,
-      showQuestionnaireOptions: true,
-      lng: lng,
-    };
+    // const featuresProps = {
+    //   title: t("features.quick.title") || "Why Choose Us",
+    //   features: features,
+    //   showQuestionnaireOptions: true,
+    //   lng: lng,
+    // };
 
-    return (
-      <div className="relative flex flex-col min-h-screen overflow-hidden text-white bg-black">
-        <BackgroundEffects />
-        <FloatingDecorations />
+    // return (
+    //   <div className="relative flex flex-col min-h-screen overflow-hidden text-white bg-black">
+    //     <BackgroundEffects />
+    //     <FloatingDecorations />
 
-        <HomePageTracker />
+    //     <HomePageTracker />
 
-        <main className="relative z-20 flex-1">
-          <HeroSection {...heroProps} />
+    //     <main className="relative z-20 flex-1">
+    //       <HeroSection {...heroProps} />
 
-          <FeaturesSection {...featuresProps} />
-        </main>
+    //       <FeaturesSection {...featuresProps} />
+    //     </main>
 
-        <Footer copyright={t("footer.copyright")} />
-      </div>
-    );
+    //     <Footer copyright={t("footer.copyright")} />
+    //   </div>
+    // );
   };
 
   return HomeContent();

--- a/src/app/[lng]/page.tsx
+++ b/src/app/[lng]/page.tsx
@@ -1,66 +1,10 @@
-// import {getTranslation} from "@/i18n-server";
-// import BackgroundEffects from "@/components/ui/BackgroundEffects/BackgroundEffects";
-// import FloatingDecorations from "@/components/ui/FloatingDecorations/FloatingDecorations";
-// import HeroSection from "@/components/sections/HeroSection/HeroSection";
-// import FeaturesSection from "@/components/sections/FeaturesSection/FeaturesSection";
-// import Footer from "@/components/ui/Footer/Footer";
-// import HomePageTracker from "@/components/analytics/HomePageTracker";
-import { redirect } from "next/navigation";
+import {redirect} from "next/navigation";
 export default function Home({params}: {params: Promise<{lng: string}>}) {
   // Use an async IIFE to handle the Promise
   const HomeContent = async () => {
     const resolvedParams = await params;
     const lng = resolvedParams.lng;
-    // const {t} = await getTranslation(lng, "common");
     redirect(`/${lng}/questionnaire`);
-
-    // const features = [
-    //   {
-    //     title: t("features.quick.title"),
-    //     description: t("features.quick.description"),
-    //     color: "blue" as const,
-    //   },
-    //   {
-    //     title: t("features.values.title"),
-    //     description: t("features.values.description"),
-    //     color: "purple" as const,
-    //   },
-    //   {
-    //     title: t("features.insights.title"),
-    //     description: t("features.insights.description"),
-    //     color: "pink" as const,
-    //   },
-    // ];
-
-    // const heroProps = {
-    //   title: t("homepage.title"),
-    //   description: t("homepage.description"),
-    //   lng: lng,
-    // };
-
-    // const featuresProps = {
-    //   title: t("features.quick.title") || "Why Choose Us",
-    //   features: features,
-    //   showQuestionnaireOptions: true,
-    //   lng: lng,
-    // };
-
-    // return (
-    //   <div className="relative flex flex-col min-h-screen overflow-hidden text-white bg-black">
-    //     <BackgroundEffects />
-    //     <FloatingDecorations />
-
-    //     <HomePageTracker />
-
-    //     <main className="relative z-20 flex-1">
-    //       <HeroSection {...heroProps} />
-
-    //       <FeaturesSection {...featuresProps} />
-    //     </main>
-
-    //     <Footer copyright={t("footer.copyright")} />
-    //   </div>
-    // );
   };
 
   return HomeContent();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,6 @@ import { redirect } from 'next/navigation';
 import { fallbackLng } from '@/i18n-config';
 
 export default function Home() {
-  // Redirect to the default locale
-  redirect(`/${fallbackLng}`);
+  // Redirect to the questionnaire page with default locale
+  redirect(`/${fallbackLng}/questionnaire`);
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,7 @@ export default function Header() {
       <div className="mx-auto max-w-7xl">
         <div className="flex items-center justify-between p-4">
           <Link 
-            href="/" 
+            href="/questionnaire" 
             className="text-xl font-bold transition-colors duration-200 hover:text-primary"
           >
             <Image 


### PR DESCRIPTION
This pull request includes several changes to the `src/app/[lng]/page.tsx`, `src/app/page.tsx`, and `src/components/Header.tsx` files to modify the redirection behavior and update the header link. The most important changes include commenting out unused imports and sections in the home page, updating the default redirection path, and changing the header link to point to the questionnaire page.

Redirection updates:

* `src/app/[lng]/page.tsx`: Commented out unused imports and sections, and added a redirection to the questionnaire page based on the language parameter. ([src/app/[lng]/page.tsxL1-R63](diffhunk://#diff-683fb00b8342c4f0a6f9778a942b4a53c6edd2a254f23257e8ca458ec2ddcc5dL1-R63))
* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL5-R6): Changed the default redirection path to the questionnaire page with the default locale.

Header link update:

* [`src/components/Header.tsx`](diffhunk://#diff-940a5ae8f5fb47c5c177e82e62f63d31a84d367613d20e22294c818fd4bc562fL20-R20): Updated the header link to point to the questionnaire page instead of the home page.