### PR TITLE
82 Remove company sizes, company external links, and change text

### DIFF
--- a/public/locales/en/ai.json
+++ b/public/locales/en/ai.json
@@ -227,7 +227,7 @@
     }
   },
   "cta": {
-    "title": "By registering with BaseMe, \nyou can view information about info sessions, events, and internships from companies that match you.",
+    "title": "Find more info on company events, internships and more on BaseMe",
     "benefit1": {
       "title": "Personalized Matches",
       "description": "Powered by BaseMe AI"
@@ -240,7 +240,7 @@
       "title": "Browse Companies",
       "description": "Access partner listings"
     },
-    "primaryButton": "Sign up with Email",
+    "primaryButton": "Sign up with BaseMe",
     "secondaryButton": "Continue with Google",
     "disclaimer": "By signing up, you agree to our Terms and Privacy Policy."
   },

--- a/public/locales/ja/ai.json
+++ b/public/locales/ja/ai.json
@@ -227,7 +227,7 @@
     }
   },
   "cta": {
-    "title": "BaseMeに登録すると、\nあなたにマッチする企業の説明会、イベント、インターン情報を見ることができます。",
+    "title": "BaseMeに登録すると、\nあなたにマッチする企業の説明会、イベント、インターン情報を見れます。",
     "benefit1": {
       "title": "パーソナライズされたマッチング",
       "description": "BaseMe AIを活用"
@@ -240,7 +240,7 @@
       "title": "企業を閲覧",
       "description": "パートナー企業情報にアクセス"
     },
-    "primaryButton": "メールで登録",
+    "primaryButton": "BaseMeに登録する",
     "secondaryButton": "Googleで続ける",
     "disclaimer": "利用を開始することで、利用規約とプライバシーポリシーに同意したものとみなされます。"
   },

--- a/src/components/recommendations/CompanyCard.tsx
+++ b/src/components/recommendations/CompanyCard.tsx
@@ -4,7 +4,7 @@ import {Button} from "@/components/ui/button";
 import {Avatar, AvatarFallback, AvatarImage} from "@/components/ui/avatar";
 import {Company} from "@/lib/supabase/client";
 import {useTranslation} from "@/i18n-client";
-import {ExternalLink, EyeOff, PartyPopper, ThumbsDown} from "lucide-react";
+import {EyeOff, PartyPopper, ThumbsDown} from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -55,123 +55,151 @@ export default function CompanyCard({
   // Generate match scores from actual match ratings data
   const generateMatchScores = (): MatchScore[] => {
     const matchScores: MatchScore[] = [];
-    
+
     // Process value match ratings
     if (Object.keys(valueMatchRatings).length > 0) {
       // Convert to array of objects and sort by score (highest first)
-      const valueScores = Object.entries(valueMatchRatings).map(([name, score]) => ({
-        name: name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, ' '),
-        score: score * 10, // Convert 1-10 scale to percentage (0-100)
-        details: valueMatchingDetails[name] || '',
-        category: 'Values'
-      }));
-      
+      const valueScores = Object.entries(valueMatchRatings).map(
+        ([name, score]) => ({
+          name: name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, " "),
+          score: score * 10, // Convert 1-10 scale to percentage (0-100)
+          details: valueMatchingDetails[name] || "",
+          category: "Values",
+        })
+      );
+
       // Take top value scores for the chart (limit to top 3)
-      matchScores.push(...valueScores.sort((a, b) => b.score - a.score).slice(0, 3));
+      matchScores.push(
+        ...valueScores.sort((a, b) => b.score - a.score).slice(0, 3)
+      );
     }
-    
+
     // Process strength match ratings
     if (Object.keys(strengthMatchRatings).length > 0) {
       // Convert to array of objects and sort by score (highest first)
-      const strengthScores = Object.entries(strengthMatchRatings).map(([name, score]) => ({
-        name: name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, ' '),
-        score: score * 10, // Convert 1-10 scale to percentage (0-100)
-        details: strengthMatchingDetails[name] || '',
-        category: 'Strengths'
-      }));
-      
+      const strengthScores = Object.entries(strengthMatchRatings).map(
+        ([name, score]) => ({
+          name: name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, " "),
+          score: score * 10, // Convert 1-10 scale to percentage (0-100)
+          details: strengthMatchingDetails[name] || "",
+          category: "Strengths",
+        })
+      );
+
       // Take top strength scores for the chart (limit to top 2)
-      matchScores.push(...strengthScores.sort((a, b) => b.score - a.score).slice(0, 2));
+      matchScores.push(
+        ...strengthScores.sort((a, b) => b.score - a.score).slice(0, 2)
+      );
     }
-    
+
     // If we still don't have enough points (at least 3), extract from matching points
     if (matchScores.length < 3 && matchingPoints.length > 0) {
       // Create a fallback map to track categories found in matching points
-      const categoryMap: Record<string, { count: number; matchPoints: string[] }> = {};
-      
+      const categoryMap: Record<
+        string,
+        {count: number; matchPoints: string[]}
+      > = {};
+
       // Process matching points to extract key categories
-      matchingPoints.forEach(point => {
+      matchingPoints.forEach((point) => {
         // Try to extract category
         let category = "Other";
-        
+
         // Look for common categories in the matching point text
         const categoryKeywords = [
-          { term: 'culture', category: 'Culture' },
-          { term: 'value', category: 'Values' },
-          { term: 'skill', category: 'Skills' },
-          { term: 'experience', category: 'Experience' },
-          { term: 'environment', category: 'Environment' },
-          { term: 'work-life', category: 'Work-Life Balance' },
-          { term: 'leadership', category: 'Leadership' },
-          { term: 'innovation', category: 'Innovation' },
-          { term: 'growth', category: 'Growth' }
+          {term: "culture", category: "Culture"},
+          {term: "value", category: "Values"},
+          {term: "skill", category: "Skills"},
+          {term: "experience", category: "Experience"},
+          {term: "environment", category: "Environment"},
+          {term: "work-life", category: "Work-Life Balance"},
+          {term: "leadership", category: "Leadership"},
+          {term: "innovation", category: "Innovation"},
+          {term: "growth", category: "Growth"},
         ];
-        
+
         for (const keyword of categoryKeywords) {
           if (point.toLowerCase().includes(keyword.term)) {
             category = keyword.category;
             break;
           }
         }
-        
+
         // Track the category
         if (!categoryMap[category]) {
-          categoryMap[category] = { count: 0, matchPoints: [] };
+          categoryMap[category] = {count: 0, matchPoints: []};
         }
-        
+
         categoryMap[category].count += 1;
         categoryMap[category].matchPoints.push(point);
       });
-      
+
       // Convert to scores and add to matchScores
       const additionalScores = Object.entries(categoryMap)
-        .filter(([name]) => !matchScores.some(score => score.name.includes(name))) // Avoid duplicates
+        .filter(
+          ([name]) => !matchScores.some((score) => score.name.includes(name))
+        ) // Avoid duplicates
         .map(([name, data]) => ({
           name,
           score: 75 + Math.min(data.count * 5, 20), // Base score 75 + up to 20 more based on count
-          details: data.matchPoints.join('. '),
-          category: 'Match Categories'
+          details: data.matchPoints.join(". "),
+          category: "Match Categories",
         }))
         .sort((a, b) => b.score - a.score);
-      
+
       // Add enough to reach at least 5 total points
       matchScores.push(...additionalScores.slice(0, 5 - matchScores.length));
     }
-    
+
     // Ensure we have at least 3 categories for the radar chart
     if (matchScores.length < 3) {
       // Use the company values to create fallback categories
       if (company.values) {
         const companyValueScores = Object.entries(company.values)
-          .filter(([key]) => ['innovation', 'work_life_balance', 'diversity_inclusion', 'career_growth'].includes(key))
+          .filter(([key]) =>
+            [
+              "innovation",
+              "work_life_balance",
+              "diversity_inclusion",
+              "career_growth",
+            ].includes(key)
+          )
           .map(([key, value]) => ({
-            name: key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, ' '),
+            name: key.charAt(0).toUpperCase() + key.slice(1).replace(/_/g, " "),
             score: value * 10, // Convert to percentage
-            details: `Company rates ${value}/10 for ${key.replace(/_/g, ' ')}`,
-            category: 'Company Values'
+            details: `Company rates ${value}/10 for ${key.replace(/_/g, " ")}`,
+            category: "Company Values",
           }))
           .sort((a, b) => b.score - a.score);
-          
+
         // Add enough to reach at least 5 total points
-        matchScores.push(...companyValueScores.slice(0, 5 - matchScores.length));
+        matchScores.push(
+          ...companyValueScores.slice(0, 5 - matchScores.length)
+        );
       }
-      
+
       // If we still don't have enough, add generic categories
-      const defaultCategories = ['Culture Fit', 'Skills Match', 'Value Alignment', 'Growth Potential', 'Work Environment'];
+      const defaultCategories = [
+        "Culture Fit",
+        "Skills Match",
+        "Value Alignment",
+        "Growth Potential",
+        "Work Environment",
+      ];
       let i = 0;
       while (matchScores.length < 5 && i < defaultCategories.length) {
-        if (!matchScores.some(score => score.name === defaultCategories[i])) {
+        if (!matchScores.some((score) => score.name === defaultCategories[i])) {
           matchScores.push({
             name: defaultCategories[i],
             score: 70 + Math.floor(Math.random() * 15),
-            details: 'Based on overall company profile',
-            category: 'General Fit'
+            details: "Based on overall company profile",
+            category: "General Fit",
           });
         }
         i++;
       }
     }
-    
+
     // Limit to 5 categories for the pentagon chart
     return matchScores.slice(0, 5);
   };
@@ -394,22 +422,6 @@ export default function CompanyCard({
               >
                 {shouldAnonymize ? getAnonymousName() : company.name}
               </span>
-
-              {!shouldAnonymize && company.site_url && (
-                <a
-                  href={
-                    company.site_url.startsWith("http")
-                      ? company.site_url
-                      : `https://${company.site_url}`
-                  }
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-white/70 transition-all hover:text-white"
-                  aria-label={`Visit ${company.name} website`}
-                >
-                  <ExternalLink size={16} />
-                </a>
-              )}
             </div>
 
             <span
@@ -429,14 +441,19 @@ export default function CompanyCard({
           <div className="flex flex-col gap-4">
             {/* Match Score Visualization - Only show when not anonymized or after feedback */}
             {(!shouldAnonymize || feedback) && (
-              <div className={`w-full transition-opacity duration-300 ${wasAnonymous && feedback ? "reveal-chart" : ""}`}>
+              <div
+                className={`w-full transition-opacity duration-300 ${
+                  wasAnonymous && feedback ? "reveal-chart" : ""
+                }`}
+              >
                 <h3 className="mb-1 text-sm font-medium text-white">
                   {t("recommendations.matchScore") || "Match Breakdown"}
                 </h3>
                 <div className="mt-1 text-xs text-white/60 mb-1">
-                  {t("recommendations.hoverForDetails") || "Hover/tap categories for details"}
+                  {t("recommendations.hoverForDetails") ||
+                    "Hover/tap categories for details"}
                 </div>
-                <MatchScoreChart 
+                <MatchScoreChart
                   matchingScores={matchScores}
                   className="mt-2"
                 />

--- a/src/components/recommendations/RecommendationsContent.tsx
+++ b/src/components/recommendations/RecommendationsContent.tsx
@@ -17,7 +17,6 @@ import {Company} from "@/lib/supabase/client";
 import {useTranslation} from "@/i18n-client";
 import SignupDialog from "@/components/recommendations/SignupDialog";
 import AnimatedContent from "@/components/ui/Animations/AnimatedContent/AnimatedContent";
-import RecommendationTabs from "@/components/recommendations/RecommendationTabs";
 import {useIsMobile} from "@/hooks/useIsMobile";
 import {
   trackRecommendationsPageVisit,
@@ -46,8 +45,6 @@ export default function RecommendationsContent({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
-  const [activeTab, setActiveTab] = useState("all");
-  const [activeSizeTab, setActiveSizeTab] = useState("all-sizes");
   const [isSignupDialogOpen, setSignupDialogOpen] = useState(false);
   const [, setFeedbackCount] = useState(0);
   const [hasClosedDialog, setHasClosedDialog] = useState(false);
@@ -393,55 +390,6 @@ export default function RecommendationsContent({
     setHasClosedDialog(true);
   };
 
-  // Function to get the filtered recommendations based on both tabs
-  const getFilteredRecommendations = () => {
-    // Helper function to determine company size category
-    const getSizeCategory = (sizeText: string, industry?: string): string => {
-      const normalizedSize = sizeText.toLowerCase();
-      const normalizedIndustry = industry?.toLowerCase() || "";
-
-      if (
-        normalizedSize.includes("startup") ||
-        normalizedSize.includes("スタートアップ") ||
-        normalizedIndustry.includes("startup") ||
-        normalizedIndustry.includes("スタートアップ")
-      ) {
-        return "startup";
-      }
-      if (normalizedSize.includes("small") || normalizedSize.includes("小")) {
-        return "small";
-      }
-      if (normalizedSize.includes("medium") || normalizedSize.includes("中")) {
-        return "medium";
-      }
-      if (normalizedSize.includes("large") || normalizedSize.includes("大")) {
-        return "large";
-      }
-      return "unknown";
-    };
-
-    // First filter by feedback status
-    let filtered = [...recommendations];
-    if (activeTab === "interested") {
-      filtered = filtered.filter((rec) => rec.feedback === "interested");
-    } else if (activeTab === "not-interested") {
-      filtered = filtered.filter((rec) => rec.feedback === "not_interested");
-    } else if (activeTab === "pending") {
-      filtered = filtered.filter((rec) => !rec.feedback);
-    }
-
-    // Then filter by size if not "all-sizes"
-    if (activeSizeTab !== "all-sizes") {
-      filtered = filtered.filter(
-        (rec) =>
-          getSizeCategory(rec.company.size, rec.company.industry) ===
-          activeSizeTab.replace("-sizes", "")
-      );
-    }
-
-    return filtered;
-  };
-
   // Show loading state while translations are loading
   if (!loaded) {
     return (
@@ -535,15 +483,6 @@ export default function RecommendationsContent({
           </p>
         </AnimatedContent>
 
-        <RecommendationTabs
-          lng={lng}
-          recommendations={recommendations}
-          activeTab={activeTab}
-          setActiveTab={setActiveTab}
-          activeSizeTab={activeSizeTab}
-          setActiveSizeTab={setActiveSizeTab}
-        />
-
         {/* Display filtered recommendations */}
         <div className="mt-3 space-y-4 sm:mt-6 sm:space-y-6">
           {isStreaming && recommendations.length === 0 ? (
@@ -555,8 +494,8 @@ export default function RecommendationsContent({
                 <div className="w-6 h-6 border-t-2 border-b-2 border-blue-500 rounded-full animate-spin"></div>
               </div>
             </div>
-          ) : getFilteredRecommendations().length > 0 ? (
-            getFilteredRecommendations().map((recommendation, index) => (
+          ) : recommendations.length > 0 ? (
+            recommendations.map((recommendation, index) => (
               <AnimatedContent
                 key={recommendation.id || recommendation.company.id}
                 direction="vertical"
@@ -572,7 +511,9 @@ export default function RecommendationsContent({
                   valueMatchRatings={recommendation.value_match_ratings}
                   strengthMatchRatings={recommendation.strength_match_ratings}
                   valueMatchingDetails={recommendation.value_matching_details}
-                  strengthMatchingDetails={recommendation.strength_matching_details}
+                  strengthMatchingDetails={
+                    recommendation.strength_matching_details
+                  }
                   feedback={recommendation.feedback}
                   onFeedback={(feedbackType) =>
                     recommendation.id &&


### PR DESCRIPTION
This pull request includes updates to localization files and refactoring of the `CompanyCard` and `RecommendationsContent` components. The most important changes include modifications to the English and Japanese localization files, removal of unused imports, and code refactoring to improve readability and maintainability.

Localization updates:

* [`public/locales/en/ai.json`](diffhunk://#diff-9cc7fff42318cd3a5959f0e4ea2c05763b13b9c6abebd46c74f90ced1f37ae3dL230-R230): Updated the call-to-action titles and button text for better clarity. [[1]](diffhunk://#diff-9cc7fff42318cd3a5959f0e4ea2c05763b13b9c6abebd46c74f90ced1f37ae3dL230-R230) [[2]](diffhunk://#diff-9cc7fff42318cd3a5959f0e4ea2c05763b13b9c6abebd46c74f90ced1f37ae3dL243-R243)
* [`public/locales/ja/ai.json`](diffhunk://#diff-fbb4bb294f732136beb312efcc2c958d54554278e526f9dc4941291c578f9f4dL230-R230): Updated the call-to-action titles and button text for better clarity. [[1]](diffhunk://#diff-fbb4bb294f732136beb312efcc2c958d54554278e526f9dc4941291c578f9f4dL230-R230) [[2]](diffhunk://#diff-fbb4bb294f732136beb312efcc2c958d54554278e526f9dc4941291c578f9f4dL243-R243)

Code refactoring:

* [`src/components/recommendations/CompanyCard.tsx`](diffhunk://#diff-73e8996da0930b097b4f66c8a5b9b1d5a21d45a6f6ebd9a58c1b812b99d2944dL7-R7): Removed the `ExternalLink` import, refactored the code for better readability, and removed the company website link. [[1]](diffhunk://#diff-73e8996da0930b097b4f66c8a5b9b1d5a21d45a6f6ebd9a58c1b812b99d2944dL7-R7) [[2]](diffhunk://#diff-73e8996da0930b097b4f66c8a5b9b1d5a21d45a6f6ebd9a58c1b812b99d2944dL62-R118) [[3]](diffhunk://#diff-73e8996da0930b097b4f66c8a5b9b1d5a21d45a6f6ebd9a58c1b812b99d2944dL397-L412)
* [`src/components/recommendations/RecommendationsContent.tsx`](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L20): Removed the `RecommendationTabs` component and the related state and filtering logic. [[1]](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L20) [[2]](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L49-L50) [[3]](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L538-L546) [[4]](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L558-R498) [[5]](diffhunk://#diff-4497dba7d416c520c78a940f2bdb2e237db064f525bac9f40dfff70afefba857L575-R516)