### PR TITLE
Set end date to the end of the day in analytics route for custom time

### DIFF
--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -59,6 +59,9 @@ export async function GET(
       startDate = new Date(startDateParam);
       endDate = new Date(endDateParam);
 
+      // Set end date to end of day (23:59:59.999)
+      endDate.setHours(23, 59, 59, 999);
+
       // Validate dates
       if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
         return NextResponse.json({ error: 'Invalid date format' }, { status: 400 });


### PR DESCRIPTION
This pull request includes a small but important change to the `src/app/api/admin/analytics/route.ts` file. The change ensures that the `endDate` is set to the end of the day (23:59:59.999) to capture the entire day's data.

* [`src/app/api/admin/analytics/route.ts`](diffhunk://#diff-80416e720a0a40a09cc052d563f0d2ec6c6bf06bf3dcedfb921c9d2556f03896R62-R64): Added logic to set the `endDate` to the end of the day (23:59:59.999) to ensure full day data is included.